### PR TITLE
Removed "isAvailable()" method

### DIFF
--- a/app/code/community/Laybuy/Payments/Model/Payments.php
+++ b/app/code/community/Laybuy/Payments/Model/Payments.php
@@ -304,12 +304,6 @@ class Laybuy_Payments_Model_Payments extends Mage_Payment_Model_Method_Abstract 
         
     }
     
-    
-    public function isAvailable($quote = NULL) {
-        
-        return $this->getConfigData('active') ? TRUE : FALSE;
-    }
-    
     /**
      * Instantiate state and set it to state object
      *


### PR DESCRIPTION
Method "isAvailable" override parent method that dispatched the event **"payment_method_is_active"**.
Parent method already use "getConfigData('active')". No need to use it in `Laybuy/Payments/Model/Payments.php` file.